### PR TITLE
fix(it-tools): Cleanup git checkout command

### DIFF
--- a/apps/it-tools/Dockerfile
+++ b/apps/it-tools/Dockerfile
@@ -3,9 +3,8 @@ ARG VERSION
 FROM node:lts-alpine AS build
 RUN \
   apk add --no-cache curl git \
-  && git clone https://github.com/CorentinTh/it-tools.git /app \
+  && git clone -b $VERSION --single-branch https://github.com/CorentinTh/it-tools.git /app \
   && cd /app \
-  && git checkout $VERSION \
   && corepack enable  \
   && corepack prepare pnpm@latest --activate \
   && pnpm install --prefer-offline \

--- a/apps/it-tools/Dockerfile
+++ b/apps/it-tools/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION
 FROM node:lts-alpine AS build
 RUN \
   apk add --no-cache curl git \
-  && git clone -b $VERSION --single-branch https://github.com/CorentinTh/it-tools.git /app \
+  && git clone -b v${VERSION} --single-branch https://github.com/CorentinTh/it-tools.git /app \
   && cd /app \
   && corepack enable  \
   && corepack prepare pnpm@latest --activate \


### PR DESCRIPTION
This checks out just the specific branch in a one-liner, which should speed up build times and reduce image size.