### PR TITLE
fix(piped-frontend): rewrite back to index if file_server 404

### DIFF
--- a/.github/workflows/workflow_call-build_image.yaml
+++ b/.github/workflows/workflow_call-build_image.yaml
@@ -153,5 +153,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           build-args: ${{ inputs.build-args }}
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/build-cache:${{ inputs.app }}
+          cache-to: ${{ inputs.dry-run && '' || "type=registry,ref=ghcr.io/${{ github.repository_owner }}/build-cache:${{ inputs.app }}" }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/build-cache:${{ inputs.app }},mode=max

--- a/apps/piped-frontend/Caddyfile
+++ b/apps/piped-frontend/Caddyfile
@@ -2,8 +2,17 @@
   order replace after encode
 }
 
-:8080 {
-  root * /app
+(frontend) {
   replace "pipedapi.kavin.rocks" "{env.BACKEND_HOSTNAME}"
   file_server
+}
+
+:8080 {
+  log
+  root * /app
+  import frontend
+  handle_errors {
+    rewrite * /
+    import frontend
+  }
 }

--- a/apps/piped-frontend/Caddyfile
+++ b/apps/piped-frontend/Caddyfile
@@ -7,7 +7,6 @@
   file_server {
     status 200
   }
-
 }
 
 :8080 {

--- a/apps/piped-frontend/Caddyfile
+++ b/apps/piped-frontend/Caddyfile
@@ -4,7 +4,10 @@
 
 (frontend) {
   replace "pipedapi.kavin.rocks" "{env.BACKEND_HOSTNAME}"
-  file_server
+  file_server {
+    status 200
+  }
+
 }
 
 :8080 {


### PR DESCRIPTION
# Description

Fixes issue where directly navigating to video slug URLs (e.g. https://piped-frontend/watch?v=dQw4w9WgXcQ or https://piped-frontend/dQw4w9WgXcQ) using browser's URL bar (example user flow: copy paste YouTube link into URL bar, then change YouTube domain to Piped frontend) results in blank page.

# Problem Technical Breakdown

Caddy tries to find the path as a file, and since neither of those are a file, it renders the Caddy error page which is a blank page.

# Solution

Have Caddy return index.html when an error response should be sent, which allows the Piped frontend to route the video slug paths, while still replacing the Piped backend hostname.

Piped frontend has its own 404 page, so an error page will still be shown to users on actual errors.

I have tested that this solution fixes the problem I'm describing, videos now load in a fresh incognito using the example user flow described above.