### PR TITLE
fix(piped-frontend): add Cache-Control response header if missing

### DIFF
--- a/apps/piped-frontend/Caddyfile
+++ b/apps/piped-frontend/Caddyfile
@@ -12,6 +12,7 @@
 :8080 {
   log
   root * /app
+  header +Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0"
   import frontend
   handle_errors {
     rewrite * /


### PR DESCRIPTION
# Description

Add Cache-Control response header if response doesn't already include one to force iOS PWA to not cache anything to prevent it from incorrectly caching errors.

# Problem Technical Breakdown

iOS PWA seems to incorrectly indefinitely (or at least for more than a whole day) cache errors connecting to piped-frontend instead of caching the actual 200 content before that.

# Solution

Add Cache-Control response header if missing.

Tested with a Piped iOS PWA that had errors connecting once (from VPN disabled) and was stuck on white screen despite connectivity being restored, once adding Cache-Control and restarting the PWA a few times it came back to life.