### PR TITLE
fix(gluetun-qb-port-sync): Use new portforward endpoint

### DIFF
--- a/apps/gluetun-qb-port-sync/scripts/script.sh
+++ b/apps/gluetun-qb-port-sync/scripts/script.sh
@@ -46,7 +46,7 @@ get_gluetun_external_ip() {
 
 get_gluetun_forwarded_port() {
   local output
-  output=$(query_gluetun_control_server "/v1/openvpn/portforwarded")
+  output=$(query_gluetun_control_server "/v1/portforward")
   echo "${output}" | jq -r .'port'
 }
 


### PR DESCRIPTION
## Summary

Gluetun v3.41.0 renamed the port forwarding endpoint from `/v1/openvpn/portforwarded` to `/v1/portforward`, returning a 301 redirect for backwards compatibility.

However, the curl command in `query_gluetun_control_server()` doesn't use the `-L` flag to follow redirects, causing jq to fail parsing the redirect response body.

This PR updates the endpoint to use the new canonical path directly.

## References

- Gluetun v3.41.0 release: https://github.com/qdm12/gluetun/releases/tag/v3.41.0
- Gluetun redirect implementation: https://github.com/qdm12/gluetun/blob/main/internal/server/openvpn.go